### PR TITLE
Add Google color reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 2.3.2
+
+* Introduce Google Blue color.
+
 ## 2.3.1
 
 * _No color changes._

--- a/docs/source/stylesheets/example-calypso-simplenote/overrides/calypso-color-schemes/shared/_color-schemes.scss
+++ b/docs/source/stylesheets/example-calypso-simplenote/overrides/calypso-color-schemes/shared/_color-schemes.scss
@@ -229,6 +229,7 @@
   --color-eventbrite: #ff8000;
   --color-facebook: #39579a;
   --color-gplus: #df4a32;
+  --color-google: #4285F4;
   --color-instagram: #d93174;
   --color-linkedin: #0976b4;
   --color-pinterest: #cc2127;

--- a/docs/source/stylesheets/example-calypso-woocommerce/overrides/calypso-color-schemes/shared/_color-schemes.scss
+++ b/docs/source/stylesheets/example-calypso-woocommerce/overrides/calypso-color-schemes/shared/_color-schemes.scss
@@ -229,6 +229,7 @@
   --color-eventbrite: #ff8000;
   --color-facebook: #39579a;
   --color-gplus: #df4a32;
+  --color-google: #4285F4;
   --color-instagram: #d93174;
   --color-linkedin: #0976b4;
   --color-pinterest: #cc2127;

--- a/docs/source/stylesheets/example-calypso/overrides/calypso-color-schemes/shared/_color-schemes.scss
+++ b/docs/source/stylesheets/example-calypso/overrides/calypso-color-schemes/shared/_color-schemes.scss
@@ -229,6 +229,7 @@
   --color-eventbrite: #ff8000;
   --color-facebook: #39579a;
   --color-gplus: #df4a32;
+  --color-google: #4285F4;
   --color-instagram: #d93174;
   --color-linkedin: #0976b4;
   --color-pinterest: #cc2127;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/color-studio",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "The color palette for Automattic products.",
   "homepage": "https://color-studio.blog",
   "license": {


### PR DESCRIPTION
This new reference could then be used in projects like this one:
https://github.com/Automattic/jetpack/pull/16633/

I added the references and edited the changelog, but I am not quite sure how / if I'm supposed to updated all references to the version number in the built artifacts. 