### PR TITLE
Replace calypso's clone branch from master to trunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "build": "yarn palette:build && yarn docs:build --silent && yarn sketch:build --quiet && yarn meta:build",
     "calypso": "yarn calypso:clone && yarn calypso:reset",
-    "calypso:clone": "git clone -b master --single-branch https://github.com/Automattic/wp-calypso .cache/calypso || true",
+    "calypso:clone": "git clone -b trunk --single-branch https://github.com/Automattic/wp-calypso .cache/calypso || true",
     "calypso:reset": "git -C .cache/calypso reset --hard 31f0c014fcbfbf20161d2ad47d1228ee9cf27970",
     "clean": "yarn palette:clean",
     "docs": "yarn docs:build",


### PR DESCRIPTION
Since calypso renamed master to trunk `yarn install` failed. Replaced it master with trunk in calypso clone command.

## Testing Instructions
1. On master branch run `yarn install`, the installation should fail
2. On this branch run `yarn install`, the installation should be successful. 