### PR TITLE
Configure CI to Guard Against Unintentional Color Changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,7 @@ jobs:
       - checkout
       - run:
         - name: Cache color values
-        - command: |
-            mkdir -p .cache
-            cp dist/colors.json .cache
+        - command: mkdir -p .cache && cp dist/colors.json .cache
       - run: yarn
       - run: yarn palette:build:json
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: yarn
-      - run: yarn palette:builde
+      - run: yarn palette:build
 
   lint:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,20 @@ jobs:
       - run: yarn
       - run: yarn lint
 
-  no-color-changes:
+  no-uncomitted-color-changes:
     executor: node
     steps:
       - checkout
-      - run: cp dist/colors.json .cache
+      - run:
+        - name: Cache color values
+        - command: |
+            mkdir -p .cache
+            cp dist/colors.json .cache
       - run: yarn
       - run: yarn palette:build:json
-      - run: cmp .cache/colors.json dist/colors.json
+      - run:
+        - name: Compare color values
+        - command: cmp .cache/colors.json dist/colors.json
 
 workflows:
   version: 2
@@ -35,4 +41,4 @@ workflows:
     jobs:
       - build
       - lint
-      - no-color-changes
+      - no-uncomitted-color-changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,18 @@ jobs:
       - run: yarn
       - run: yarn lint
 
+  no-color-changes:
+    executor: node
+    steps:
+      - checkout
+      - run: cp dist/colors.json .cache
+      - run: yarn
+      - run: yarn palette:build:json
+      - run: cmp .cache/colors.json dist/colors.json
+
 workflows:
   version: 2
   main:
     jobs:
       - lint
+      - no-color-changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,13 @@ executors:
       - image: circleci/node:lts
 
 jobs:
+  build:
+    executor: node
+    steps:
+      - checkout
+      - run: yarn
+      - run: yarn palette:builde
+
   lint:
     executor: node
     steps:
@@ -26,5 +33,6 @@ workflows:
   version: 2
   main:
     jobs:
+      - build
       - lint
       - no-color-changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,15 +25,15 @@ jobs:
     steps:
       - checkout
       - run:
-        - name: "Cache color values"
-        - command: |
+          name: Cache color values
+          command: |
             mkdir -p .cache
             cp dist/colors.json .cache
       - run: yarn
       - run: yarn palette:build:json
       - run:
-        - name: "Compare color values"
-        - command: cmp .cache/colors.json dist/colors.json
+          name: Compare color values
+          command: cmp .cache/colors.json dist/colors.json
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2.1
+
+executors:
+  node:
+    docker:
+      - image: circleci/node:lts
+
+jobs:
+  lint:
+    executor: node
+    steps:
+      - checkout
+      - run: yarn
+      - run: yarn lint
+
+workflows:
+  version: 2
+  main:
+    jobs:
+      - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,14 @@ jobs:
     steps:
       - checkout
       - run:
-        - name: Cache color values
-        - command: mkdir -p .cache && cp dist/colors.json .cache
+        - name: "Cache color values"
+        - command: |
+            mkdir -p .cache
+            cp dist/colors.json .cache
       - run: yarn
       - run: yarn palette:build:json
       - run:
-        - name: Compare color values
+        - name: "Compare color values"
         - command: cmp .cache/colors.json dist/colors.json
 
 workflows:


### PR DESCRIPTION
The `no-uncommitted-color-changes` guard will fail whenever it encounters any unintentional changes to `dist/colors.json`. Those can happen due to dependency updates and other automatic processes.