### PR TITLE
perf: use Clipboard API

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,4 @@ updates:
     schedule:
       interval: "monthly"
     versioning-strategy: "increase-if-necessary"
-    ignore:
-      - dependency-name: "copy-text-to-clipboard"
-        versions:
-        - ">= 3.0.0"
+

--- a/docs/source/javascripts/docs/docs-debug.js
+++ b/docs/source/javascripts/docs/docs-debug.js
@@ -1,4 +1,3 @@
-const copyToClipboard = require('copy-text-to-clipboard')
 const forIn = require('lodash/forIn')
 const groupBy = require('lodash/groupBy')
 const toArray = require('lodash/toArray')
@@ -81,6 +80,6 @@ function renderTiles(palette) {
 function activateTiles(scope = document) {
   toArray(scope.querySelectorAll('.tile')).forEach(element => {
     const color = String(element.dataset.color).trim()
-    element.addEventListener('click', () => copyToClipboard(color))
+    element.addEventListener('click', () => navigator.clipboard.writeText(color))
   })
 }

--- a/docs/source/javascripts/docs/docs-index.js
+++ b/docs/source/javascripts/docs/docs-index.js
@@ -1,4 +1,3 @@
-const copyToClipboard = require('copy-text-to-clipboard')
 const forIn = require('lodash/forIn')
 const groupBy = require('lodash/groupBy')
 const toArray = require('lodash/toArray')
@@ -81,6 +80,6 @@ function renderTiles(palette) {
 function activateTiles(scope = document) {
   toArray(scope.querySelectorAll('.tile')).forEach(element => {
     const color = String(element.dataset.color).trim()
-    element.addEventListener('click', () => copyToClipboard(color))
+    element.addEventListener('click', () => navigator.clipboard.writeText(color))
   })
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "bootstrap": "5.3.8",
     "chroma-js": "3.2.0",
     "concurrently": "9.2.1",
-    "copy-text-to-clipboard": "2.2.0",
     "css-loader": "7.1.4",
     "easy-table": "1.2.0",
     "husky": "9.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,11 +4157,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==
 
-copy-text-to-clipboard@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz#329dd6daf8c42034c763ace567418401764579ae"
-  integrity sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ==
-
 core-js-compat@^3.43.0, core-js-compat@^3.48.0:
   version "3.48.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.48.0.tgz#7efbe1fc1cbad44008190462217cc5558adaeaa6"


### PR DESCRIPTION
Removes a dependency in favor of the widely supported [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API). This PR was made as part of the [e18e initiative](https://e18e.dev/).