### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.14.3"
+        uses: "pascalgn/automerge-action@04dfc9eae2586d19b7362d4f6413c48135d9c25a" # v0.14.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "Dependencies"


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to commit SHAs (with the original tag preserved as a trailing comment), to harden against supply-chain attacks via mutable tags.

Refresh path: #907 (draft) adds Dependabot for `github-actions` so these SHAs auto-update once both PRs land.

Tracking: DEVPROD-1072.
