### PR TITLE
chore: enable Dependabot for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,14 @@ updates:
       - dependency-name: "copy-text-to-clipboard"
         versions:
         - ">= 3.0.0"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds the `github-actions` ecosystem to Dependabot so SHA-pinned actions get automatic refresh PRs (grouped weekly to limit volume).

Tracking: DEVPROD-1072. Paired with #906.
