### PR TITLE
Fix minimatch dependency alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6647,9 +6647,9 @@ minimatch@^10.2.2, minimatch@^10.2.4:
     brace-expansion "^5.0.5"
 
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
## Summary
- Updates the vulnerable `minimatch@^3.x` transitive resolution in `yarn.lock` from 3.1.2 to 3.1.5.
- Leaves package manifests unchanged.

## Validation
- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn why minimatch --ignore-scripts`
- `git diff --check`
